### PR TITLE
Fix: Add null safety check for optional priceUSD in order items

### DIFF
--- a/components/OrderSuccess.tsx
+++ b/components/OrderSuccess.tsx
@@ -94,7 +94,7 @@ export default function OrderSuccess({
                     </div>
                     {/* Total price for this item */}
                     <div className="text-base font-semibold w-20 text-right">
-                      ${(item.priceUSD * item.quantity).toFixed(2)}
+                      ${((item.priceUSD ?? 0) * item.quantity).toFixed(2)}
                     </div>
                   </div>
                 ))


### PR DESCRIPTION
## Summary
- Fixed potential runtime error in OrderSuccess component where `priceUSD` could be undefined
- Added nullish coalescing operator (`??`) to safely handle missing price values

## Problem
The `OrderItem` interface defines `priceUSD` as optional (`priceUSD?: number`), but the component was using it directly in calculations without checking for `undefined`. This could cause a runtime error when rendering order items without prices.

## Solution
Updated line 97 in `components/OrderSuccess.tsx` to use the nullish coalescing operator:
```tsx
${((item.priceUSD ?? 0) * item.quantity).toFixed(2)}
```

Now defaults to `0` when `priceUSD` is undefined, preventing the error and displaying `$0.00` for items without prices.

## Test Plan
- [ ] Verify order success page displays correctly for orders with valid prices
- [ ] Test with order items that have missing/undefined prices
- [ ] Ensure the total calculation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)