### PR TITLE
Add welcome banner with free shipping message

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,6 +62,13 @@ export default function HomePage() {
         height={260}
       />
 
+      {/* Welcome Banner - NEW */}
+      <div className="bg-stone-100 py-4 px-6 text-center">
+        <p className="text-stone-700 font-medium">
+          Welcome to our store! Free shipping on orders over $100.
+        </p>
+      </div>
+
       {/* Just In Section */}
       <section className="py-12 px-6 max-w-7xl mx-auto">
         <div className="flex items-center justify-between mb-6">


### PR DESCRIPTION
This PR adds a welcome banner below the hero image that displays a free shipping message for orders over $100.

**Changes:**
- Added a new welcome banner section on the homepage
- Banner has stone-100 background with centered text

**Testing:**
- Verify the banner appears below the hero image
- Verify the text is readable and centered