### PR TITLE
Rename Just In section to New Arrivals

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,7 +65,7 @@ export default function HomePage() {
       {/* Just In Section */}
       <section className="py-12 px-6 max-w-7xl mx-auto">
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-3xl font-semibold">Just In</h2>
+          <h2 className="text-3xl font-semibold">New Arrivals</h2>
           <Link
             href="/shop/just-in"
             className="text-stone-700 flex items-center group"


### PR DESCRIPTION
This PR renames the 'Just In' section heading to 'New Arrivals' on the homepage.

**Changes:**
- Updated the section heading text from 'Just In' to 'New Arrivals'

**Testing:**
- Verify the homepage displays 'New Arrivals' as the section heading